### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://user-images.githubusercontent.com/30594/166437124-f81fc776-c72c-4332-990
 Install the support Julia package:
 ```
 using Pkg
-Pkg.add("https://github.com/andreypopp/julia-repl-vim")
+Pkg.add(url="https://github.com/andreypopp/julia-repl-vim")
 ```
 
 Now when you start `julia` you can do:


### PR DESCRIPTION
Pkg.add("some-url") errors on Julia 1.7.3

```julia
import Pkg; Pkg.add("https://github.com/andreypopp/julia-repl-vim.git")
```
ERROR: `https://github.com/andreypopp/julia-repl-vim.git` is not a valid package name The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.

Changed to Pkg.add(url="some-url")