### PR TITLE
other port numbers and optional repl completion

### DIFF
--- a/lua/julia-repl.lua
+++ b/lua/julia-repl.lua
@@ -116,7 +116,9 @@ function setup(po)
     end
   }
   vim.api.nvim_buf_set_var(buf, 'julia_repl', repl)
-  --vim.api.nvim_buf_set_option(0, 'omnifunc', 'v:lua.julia_repl_comp')
+  if vim.g.julia_repl_complete then
+    vim.api.nvim_buf_set_option(0, 'omnifunc', 'v:lua.julia_repl_comp')
+  end
 end
 
 function _G.julia_repl_send(code)

--- a/lua/julia-repl.lua
+++ b/lua/julia-repl.lua
@@ -99,21 +99,24 @@ function connect(opts)
   return repl
 end
 
-function setup()
+function setup(po)
   local buf = vim.fn.bufnr()
   local ok, repl = pcall(vim.api.nvim_buf_get_var, buf, 'julia_repl')
   if ok and repl ~= nil then
     repl.close()
   end
+  if po == nil then
+    po = 2345
+  end
   repl = connect {
     host="localhost",
-    port=2345,
+    port=po,
     on_close=function()
       vim.api.nvim_buf_set_var(buf, 'julia_repl', nil)
     end
   }
   vim.api.nvim_buf_set_var(buf, 'julia_repl', repl)
-  vim.api.nvim_buf_set_option(0, 'omnifunc', 'v:lua.julia_repl_comp')
+  --vim.api.nvim_buf_set_option(0, 'omnifunc', 'v:lua.julia_repl_comp')
 end
 
 function _G.julia_repl_send(code)

--- a/lua/julia-repl.lua
+++ b/lua/julia-repl.lua
@@ -1,3 +1,4 @@
+callbacks = {}
 function logerror(msg)
   vim.api.nvim_echo({{"julia-repl: "..msg, "ErrorMsg"}}, true, {})
 end
@@ -12,7 +13,6 @@ function connect(opts)
   local port = opts.port or 2345
   local buf = {}
   local id = 0
-  local callbacks = {}
 
   local on_response = function(response)
     data = vim.fn.json_decode(response)

--- a/plugin/julia-repl.vim
+++ b/plugin/julia-repl.vim
@@ -42,8 +42,8 @@ function! s:restore_cur()
   endif
 endfunction
 
-command -range -bar -nargs=0 JuliaREPLConnect
-      \ lua require('julia-repl').setup()
+command -range -bar -nargs=1 JuliaREPLConnect
+      \ lua require('julia-repl').setup(<f-args>)
 command -range -bar -nargs=0 JuliaREPLSend
       \  call s:store_cur()
       \| call s:send_range(<line1>, <line2>)


### PR DESCRIPTION
WIP , kindly let me know how i could improve this, this changes `JuliaREPLConnect` to accept an argument to connect to specified port so that repls started with other port numbers with `REPLVim.serve(portno)` can be connected to

repl complete is also made optional with `g:julia_repl_complete`. nvim becomes laggy when the REPL is doing heavy computations , this might be better of left optional